### PR TITLE
Upgrade package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ Flask-PyMongo==0.4.1
 idna==2.8
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 pymongo==3.7.1
 redis==3.2.1
 requests==2.22.0
 simplejson==3.16.0
 urllib3==1.25.3
 uWSGI==2.0.17.1
-Werkzeug==0.14.1
+Werkzeug==0.15.4


### PR DESCRIPTION
1. Upgrade package version for MarkupSafe to deal with the dependency bug.
https://github.com/pallets/markupsafe/issues/57

2. Upgrade package version for Werkzeug to satisfying to min version requirement of Eve.